### PR TITLE
Add Build-Commit-Publish Workflow to Actions

### DIFF
--- a/.github/workflows/build-commit-publish.yml
+++ b/.github/workflows/build-commit-publish.yml
@@ -1,0 +1,53 @@
+name: Build, Upload and Commit Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-upload-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install setuptools wheel build twine
+      # This ensures setuptools, wheel, build, and twine are installed
+
+    - name: Build wheels and source distribution
+      run: |
+        python setup.py bdist_wheel
+        python setup.py sdist
+        twine check dist/*
+
+    - name: Upload to PyPI
+      env:
+        PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+      run: |
+        echo "API tokens can be created at https://pypi.org/manage/account/token/"
+        python -m twine upload -u __token__ -p $PYPI_API_TOKEN dist/*
+    
+    - name: Commit Release
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        # Check if there are any changes. If there are, proceed with commit and tag.
+        if ! git diff --quiet; then
+          git add -A
+          VERSION=$(python setup.py --version)
+          git commit -m "Release v${VERSION}. [skip ci]"
+          git tag v${VERSION}
+          echo "A commit and tag for this release has been made."
+        else
+          echo "No changes to commit."
+        fi
+      shell: bash


### PR DESCRIPTION
This workflow is added in such a way that it is only triggered by button click. This is done on purpose.

Two things to note: 
1. The commit section acts to commit any previous changes made by this or other workflows. This is done for future proofing and as an examplar for commits. It will automatically be bypassed if there is nothing to commit (as is seen in this default state).
2. In order for the script to run, a secret must be added called PYPI_API_TOKEN, which is used by this script to push to pypi. In the current setup it is pushing to a CS489 account, that just a random default account. When testing, make sure that you either increment the version number or name in setup.py otherwise pushing to pypi wont work. This is a thing that pypi has done on purpose, even if you delete a version on pypi, you cannot push to that same version again. Again, if there are errors here, increment the version number or change the name.

Steps to add a secret:
1. Go to our forked repo as admin.
2. In the top bar that contains Code, Pull Requests, Actions, ... and Settings, click Settings.
3. On the left hand navigation column click Secrets and variables, then actions from the dropdown.
4. Add a new repository secret called PYPI_API_TOKEN and give it the secret code, or make another pypi account and use that code.